### PR TITLE
Fixed a couple of 404 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SubCollider.js is a JavaScript library that provides like SuperCollider function
 
 ## Documents
 
-[documents](http://mohayonao.github.com/subcollider.js/docs/)
+[documents](http://mohayonao.github.com/subcollider/docs/)
 
 ## Installation
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta property="og:title" content="subcollider.js">
     <meta property="og:description" content="SubCollider.js is a JavaScript library that provides like SuperCollider functions.">
     <meta property="og:url" content="http://mohayonao.github.io/subcollider.js">
-    <meta property="og:image" content="http://mohayonao.github.io/subcollider.js/docs/logo.png">
+    <meta property="og:image" content="http://mohayonao.github.io/subcollider/docs/logo.png">
     <meta name="description" content="SubCollider.js is a JavaScript library that provides like SuperCollider functions.">
     <meta name="keywords" content="JavaScript,SuperCollider,timbre.js">
     <link rel="shortcut icon" href="favicon.ico" id="favicon">


### PR DESCRIPTION
The link to “documents” is a 404. When I tried to fix the 404 I noticed that the link to the logo is also a 404.
